### PR TITLE
Created Categories Form [ gsh-categoriesForm ]

### DIFF
--- a/src/components/categories/CategoriesList.js
+++ b/src/components/categories/CategoriesList.js
@@ -6,10 +6,14 @@
 */
 
 import React, { useEffect, useState } from "react";
-import { getCategories } from "./CategoriesManager";
+import { useHistory } from "react-router-dom";
+import { getCategories, deleteCategory } from "./CategoriesManager";
+import { editCategory, addCategory } from "./CategoriesManager";
 
 export const CategoriesList = () => {
     const [ categories, setCategories ] = useState([])
+    const [ category, setCategory ] = useState({})
+    const history = useHistory()
 
     useEffect(() => {
         getCategories()
@@ -17,27 +21,77 @@ export const CategoriesList = () => {
     }, [])
 
 
+    const saveCategory = () => {
+        const newCategory = {
+            label: category.label
+        }
+
+        addCategory(newCategory)
+            .then(() => {
+                setCategory({label: ""})
+                getCategories()
+                    .then((category) => setCategories(category))
+            })
+    }
+
     return (
-        <>
-        {
+        <div className="categorieslist">
+            <div className="allcategories">
+            {
             categories.map(
                 (category) => {
-                    return <div className="category" key={`category--${category.id}`}>
+                    return (
+                    <>
+                        <div className="category" key={`category--${category.id}`}>
                             <article className="categorylist">                           
                                 Category: {category.label}  
 
                                 <button className="button" onClick={() => {
-                                history.push(`EditRequest/${request.id}`)
-                            }}>Edit Request</button> 
+                                history.push(`editCategory/${category.id}`)
+                                 }}>Edit Category</button> 
 
                                 <button className="button" onClick={() => {
-                                    deleteRequest(request.id)                            
-                                }}>Delete Request</button>                         
+                                    deleteCategory(category.id)                            
+                                }}>Delete Category</button>                         
                             </article>
                         </div>
+                    </>
+                    )
                 }
-            )
-        }
-        </>
+            )}
+            </div>
+                    <div className="addcategory">
+                        <form className="newCategoryForm">
+                        <h2 className="newCategoryForm__title">Create a New Category</h2>
+
+                        <fieldset>
+                            <div className="form-group">
+                                <label htmlFor="label">New category:</label>
+                                <input
+                                    onChange={
+                                        (evt) => {
+                                            const copy = {...category}
+                                            copy.label = evt.target.value
+                                            setCategory(copy)
+                                        }
+                                    }
+                                    required autoFocus
+                                    type="text"
+                                    className="form-control"
+                                    placeholder="Enter the new category..."
+                                    />
+                            </div>
+                        </fieldset>  
+                                <br></br>
+                                <button type="submit" className="btn btn-primary"
+                                    onClick={(evt) => {
+                                        evt.preventDefault()
+                                        saveCategory()
+                                    }}
+                                >Submit
+                                </button>
+                        </form>
+                    </div>
+        </div>
     )
 }

--- a/src/components/categories/CategoriesList.js
+++ b/src/components/categories/CategoriesList.js
@@ -6,20 +6,20 @@
 */
 
 import React, { useEffect, useState } from "react";
+import { getCategories, addCategory } from "./CategoriesManager";
+import { editCategory, deleteCategory } from "./CategoriesManager";  
 import { useHistory } from "react-router-dom";
-import { getCategories, deleteCategory } from "./CategoriesManager";
-import { editCategory, addCategory } from "./CategoriesManager";
 
-export const CategoriesList = () => {
-    const [ categories, setCategories ] = useState([])
-    const [ category, setCategory ] = useState({})
+
+export const CategoriesList = () => {                    
+    const [categories, setCategories] = useState([])          
+    const [category, setCategory] = useState({})            
     const history = useHistory()
 
     useEffect(() => {
-        getCategories()
-            .then((data) => setCategories(data))
+        getCategories()                                    
+            .then((category) => setCategories(category))               
     }, [])
-
 
     const saveCategory = () => {
         const newCategory = {
@@ -35,63 +35,59 @@ export const CategoriesList = () => {
     }
 
     return (
-        <div className="categorieslist">
-            <div className="allcategories">
-            {
-            categories.map(
-                (category) => {
-                    return (
-                    <>
-                        <div className="category" key={`category--${category.id}`}>
-                            <article className="categorylist">                           
-                                Category: {category.label}  
-
-                                <button className="button" onClick={() => {
-                                history.push(`editCategory/${category.id}`)
-                                 }}>Edit Category</button> 
-
-                                <button className="button" onClick={() => {
-                                    deleteCategory(category.id)                            
-                                }}>Delete Category</button>                         
-                            </article>
-                        </div>
-                    </>
-                    )
-                }
-            )}
+        <div className="columns">
+            <div className="column">
+                <ul className="categoriesList">
+                    {categories.map(category => {
+                        return <>
+                            <li className="card category--list" key={`category--${category.id}`}>
+                                <div className="category--label">
+                                    {category.label}
+                                </div>
+                                <button className="btn edit-tag">Edit</button>
+                                <button className="btn delete-tag">Delete</button>
+                            </li>
+                        </>
+                        }
+                    )}
+                </ul>
             </div>
-                    <div className="addcategory">
-                        <form className="newCategoryForm">
-                        <h2 className="newCategoryForm__title">Create a New Category</h2>
+            
+            <div className="column">
+                <form className="categoryForm">
+                    <h2 className="categoryForm__title">Create a New Category</h2>
+                    <fieldset>
+                        <div className="form-group">
+                            <input autoFocus type="text" value={category.label} className="categoryLabel" placeholder="Enter the new category..."
+                            onChange={
+                                (evt) => {
+                                    evt.preventDefault()
+                                    const copy = {...category}
+                                    copy.label = evt.target.value
+                                    setCategory(copy)
+                                }
+                            } />
+                        </div>
+                    </fieldset>
 
-                        <fieldset>
-                            <div className="form-group">
-                                <label htmlFor="label">New category:</label>
-                                <input
-                                    onChange={
-                                        (evt) => {
-                                            const copy = {...category}
-                                            copy.label = evt.target.value
-                                            setCategory(copy)
-                                        }
-                                    }
-                                    required autoFocus
-                                    type="text"
-                                    className="form-control"
-                                    placeholder="Enter the new category..."
-                                    />
-                            </div>
-                        </fieldset>  
-                                <br></br>
-                                <button type="submit" className="btn btn-primary"
-                                    onClick={(evt) => {
-                                        evt.preventDefault()
-                                        saveCategory()
-                                    }}
-                                >Submit
-                                </button>
-                        </form>
-                    </div>
+                    <button type="submit"
+                        className="btn btn-primary"
+                        onClick={(evt) => {
+                            evt.preventDefault()
+                            saveCategory()
+                        }}
+                    >Submit</button>
+                </form>
+            </div>
         </div>
     )
 }
+
+
+//                                 <button className="button" onClick={() => {
+//                                 history.push(`editCategory/${category.id}`)
+//                                  }}>Edit Category</button> 
+
+//                                 <button className="button" onClick={() => {
+//                                     deleteCategory(category.id)                            
+//                                 }}>Delete Category</button>                         

--- a/src/components/categories/CategoriesManager.js
+++ b/src/components/categories/CategoriesManager.js
@@ -1,6 +1,36 @@
 import Settings from "../repositories/Settings"
+import { CategoriesList } from "./CategoriesList"
 
 export const getCategories = () => {
     return fetch(`${Settings.remoteURL}/categories`)    
     .then(res => res.json())
 }
+
+export const deleteCategory = (id) => {
+    fetch(`http://localhost:8088/categories/${id}`, {
+        method: "DELETE"
+    })
+        .then(CategoriesList())
+}
+
+export const getSingleCategory = (id) => {
+    return fetch(`${Settings.remoteURL}/categories/${id}`)
+    .then(res => res.json())
+}
+
+export const addCategory = (newCategory) => {
+    return fetch(`${Settings.remoteURL}/categories`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(newCategory)
+    })
+}
+
+export const editCategory = (id) => {
+    fetch(`http://localhost:8088/categories/${id}`)
+            .then(res => res.json())
+}
+
+

--- a/src/components/categories/CategoriesManager.js
+++ b/src/components/categories/CategoriesManager.js
@@ -32,5 +32,3 @@ export const editCategory = (id) => {
     fetch(`http://localhost:8088/categories/${id}`)
             .then(res => res.json())
 }
-
-


### PR DESCRIPTION
# Description
# Description

This change provides a form on the `/categories` route for creating a new category. 
This is change on both the client side and the server side.

Fixes #20 “Create a Category”

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by:
- get the matching branch on the server side
- either/both:
  - - clicking the `Category Manager` link in the navbar, and/or 
  - - going directly to the URL `http://localhost:8088/categories` as a logged-in user.
- fill in the provided form and click submit.

[ ] verify that categories are still displayed (e.g.: Category: News) in a list
[ ] verify that categories are still displayed alphabetically (A-Z order). Add additional categories to the database if needed.
[ ] verify that each category has an `Edit` and `Delete` button adjacent to them. The buttons will be nonfunctional at this time.
[ ] verify that there is a form to the right of the list.
[ ] verify that you can enter a new category, click `Submit`, the page refreshes with all the categories, including your newly added category, and that they’re still in alphabetic order.